### PR TITLE
Change from .tokenUri("0") to .getDogTokenUris("0")

### DIFF
--- a/test/unit/randomIpfs.test.js
+++ b/test/unit/randomIpfs.test.js
@@ -43,7 +43,7 @@ const { developmentChains, networkConfig } = require("../../helper-hardhat-confi
                   await new Promise(async (resolve, reject) => {
                       randomIpfsNft.once("NftMinted", async () => {
                           try {
-                              const tokenUri = await randomIpfsNft.tokenURI(0)
+                              const tokenUri = await randomIpfsNft.getDogTokenUris("0")
                               const tokenCounter = await randomIpfsNft.getTokenCounter()
                               assert.equal(tokenUri.toString().includes("ipfs://"), true)
                               assert.equal(tokenCounter.toString(), "1")


### PR DESCRIPTION
I noticed that in the fulfill random words test, the portion of the test that grabs the token URI, doesn't grab the Dog Token Uris with the correct method. I also changed it from inputting a number to a string to make it more like the rest of the code.