### PR TITLE
remove obsolete from call

### DIFF
--- a/contracts/sublesson/CallAnything.sol
+++ b/contracts/sublesson/CallAnything.sol
@@ -123,9 +123,7 @@ contract CallFunctionWithoutContract {
     // pass in 0xa9059cbb000000000000000000000000d7acd2a9fd159e69bb102a1ca21c9a3e3a5f771b000000000000000000000000000000000000000000000000000000000000007b
     // you could use this to change state
     function callFunctionDirectly(bytes calldata callData) public returns (bytes4, bool) {
-        (bool success, bytes memory returnData) = s_selectorsAndSignaturesAddress.call(
-            abi.encodeWithSignature("getSelectorThree(bytes)", callData)
-        );
+        (bool success, bytes memory returnData) = s_selectorsAndSignaturesAddress.call(callData);
         return (bytes4(returnData), success);
     }
 


### PR DESCRIPTION
Function  callFunctionDirectly in CallAnything.sol has obsolete part  as if we pass in calldata suggested above that function in code commment that is abi of transfer function and parameters then
**abi.encodeWithSignature("getSelectorThree(bytes)"** part is obsolete and produces wrong result. Function needs to be as made in commit to output result properly. Tested it with remix and works as it should. Current code outputs wrong result
