### PR TITLE
fix: Remove await call from readFileSync.

### DIFF
--- a/deploy/02-deploy-dynamic-svg-nft.js
+++ b/deploy/02-deploy-dynamic-svg-nft.js
@@ -17,8 +17,8 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
         ethUsdPriceFeedAddress = networkConfig[chainId].ethUsdPriceFeed
     }
 
-    const lowSVG = await fs.readFileSync("./images/dynamicNft/frown.svg", { encoding: "utf8" })
-    const highSVG = await fs.readFileSync("./images/dynamicNft/happy.svg", { encoding: "utf8" })
+    const lowSVG = fs.readFileSync("./images/dynamicNft/frown.svg", { encoding: "utf8" })
+    const highSVG = fs.readFileSync("./images/dynamicNft/happy.svg", { encoding: "utf8" })
 
     log("----------------------------------------------------")
     arguments = [ethUsdPriceFeedAddress, lowSVG, highSVG]


### PR DESCRIPTION
No need to use `await` keyword when calling a synchronous function. Here is readFileSync.