### PR TITLE
Added another test for the "requestNFT" function

### DIFF
--- a/test/unit/randomIpfs.test.js
+++ b/test/unit/randomIpfs.test.js
@@ -30,6 +30,11 @@ const { developmentChains, networkConfig } = require("../../helper-hardhat-confi
               it("fails if payment isn't sent with the request", async function () {
                   await expect(randomIpfsNft.requestNft()).to.be.revertedWith("NeedMoreETHSent")
               })
+              it("reverts if payment amount is less than the mint fee", async function () {
+					const fee = await randomIpfsNft.getMintFee();
+					await expect(randomIpfsNft.requestNft({ value: mintFee.sub(ethers.utils.parseEther("0.001")) })
+					).to.be.revertedWith("NeedMoreETHSent");
+				});
               it("emits an event and kicks off a random word request", async function () {
                   const fee = await randomIpfsNft.getMintFee()
                   await expect(randomIpfsNft.requestNft({ value: fee.toString() })).to.emit(


### PR DESCRIPTION
Added another test (condition/statement) for the function "requestNft" when the payment amount sent is less than that of the mint fee. If there is a better (more dynamic/safe?) way to do this please share it.