### PR TITLE
Change tokenURI(0) to tokenURI(1)

### DIFF
--- a/test/unit/dynamicSvg.test.js
+++ b/test/unit/dynamicSvg.test.js
@@ -47,14 +47,14 @@ const lowTokenUri =
                   )
                   const tokenCounter = await dynamicSvgNft.getTokenCounter()
                   assert.equal(tokenCounter.toString(), "1")
-                  const tokenURI = await dynamicSvgNft.tokenURI(0)
+                  const tokenURI = await dynamicSvgNft.tokenURI(1)
                   assert.equal(tokenURI, highTokenUri)
               })
               it("shifts the token uri to lower when the price doesn't surpass the highvalue", async function () {
                   const highValue = ethers.utils.parseEther("100000000") // $100,000,000 dollar per ether. Maybe in the distant future this test will fail...
                   const txResponse = await dynamicSvgNft.mintNft(highValue)
                   await txResponse.wait(1)
-                  const tokenURI = await dynamicSvgNft.tokenURI(0)
+                  const tokenURI = await dynamicSvgNft.tokenURI(1)
                   assert.equal(tokenURI, lowTokenUri)
               })
           })


### PR DESCRIPTION
Currently in lines 50 and 57, tokenURI() passes 0 as the argument, however, this seems, according to my tests, wrong, since whenever an NFT is minted the counter is incremented by 1, thus, passing 0 will always revert. The first value will always be 1, since an NFT is minted above in line 44 and 55, accordingly.