### PR TITLE
fixed mintNft function typo

### DIFF
--- a/contracts/DynamicSvgNft.sol
+++ b/contracts/DynamicSvgNft.sol
@@ -52,8 +52,8 @@ contract DynamicSvgNft is ERC721, Ownable {
     function mintNft(int256 highValue) public {
         s_tokenIdToHighValues[s_tokenCounter] = highValue;
         _safeMint(msg.sender, s_tokenCounter);
-        s_tokenCounter = s_tokenCounter + 1;
         emit CreatedNFT(s_tokenCounter, highValue);
+        s_tokenCounter++;
     }
 
     // You could also just upload the raw SVG and have solildity convert it!


### PR DESCRIPTION
Changing the function to increment the `s_tokenCounter` after the `CreatedNFT()` event is emitted so that the `event` is emitted with the correct `tokenId`. Another solution would be to ignore this PR and just change the emit to this: 
``` solidity 
emit CreatedNFT(s_tokenCounter - 1, highValue);

```
