### PR TITLE
corrected mintNft function inside DynamicSvgNft contract

### DIFF
--- a/contracts/DynamicSvgNft.sol
+++ b/contracts/DynamicSvgNft.sol
@@ -52,8 +52,9 @@ contract DynamicSvgNft is ERC721, Ownable {
     function mintNft(int256 highValue) public {
         s_tokenIdToHighValues[s_tokenCounter] = highValue;
         _safeMint(msg.sender, s_tokenCounter);
-        s_tokenCounter = s_tokenCounter + 1;
+        // emit event first with the current tokenCounter and then increment it
         emit CreatedNFT(s_tokenCounter, highValue);
+        s_tokenCounter = s_tokenCounter + 1;
     }
 
     // You could also just upload the raw SVG and have solildity convert it!


### PR DESCRIPTION
Hello,
We should emit the CreatedNft event with the current tokenCounter and then increment it for the next mint request.