### PR TITLE
uploadToPinata.js:Upgrade to the latest version of pinata-@pinata/sdk version 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@chainlink/contracts": "^0.5.1",
     "@ethersproject/bignumber": "^5.5.0",
     "@openzeppelin/contracts": "^4.5.0",
-    "@pinata/sdk": "^1.1.23",
+    "@pinata/sdk": "^2.1.0",
     "base64-sol": "^1.1.0",
     "dotenv": "^16.0.0",
     "fs": "^0.0.1-security",

--- a/utils/uploadToPinata.js
+++ b/utils/uploadToPinata.js
@@ -10,22 +10,16 @@ async function storeImages(imagesFilePath) {
     const fullImagesPath = path.resolve(imagesFilePath)
 
     // Filter the files in case the are a file that in not a .png
-    const files = fs
-        .readdirSync(fullImagesPath)
-        .filter((file) => file.includes(".png"))
+    const files = fs.readdirSync(fullImagesPath).filter((file) => file.includes(".png"))
 
     let responses = []
     console.log("Uploading to IPFS")
 
     for (const fileIndex in files) {
-        const readableStreamForFile = fs.createReadStream(
-            `${fullImagesPath}/${files[fileIndex]}`
-        )
-        const indexForNaming = readableStreamForFile.path.lastIndexOf("/")
-
+        const readableStreamForFile = fs.createReadStream(`${fullImagesPath}/${files[fileIndex]}`)
         const options = {
             pinataMetadata: {
-                name: readableStreamForFile.path.slice(indexForNaming + 1),
+                name: files[fileIndex],
             },
         }
         try {
@@ -58,6 +52,5 @@ async function storeTokenUriMetadata(metadata) {
     }
     return null
 }
-
 
 module.exports = { storeImages, storeTokenUriMetadata }


### PR DESCRIPTION
Modified and added new updates for:

Update "@pinata/sdk" version.
Update "@nomiclabs/hardhat-ethers" version.
Update uploadToPinata.js to works with the latest version.

In this Pull Request are updated the @pinata/sdk to the latest solving the issue in https://github.com/PatrickAlphaC/hardhat-nft-fcc/issues/58 and updating the repository to the latest version of pinata.