### PR TITLE
corrected owner logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@chainlink/contracts": "^0.5.1",
     "@ethersproject/bignumber": "^5.5.0",
     "@openzeppelin/contracts": "^4.5.0",
-    "@pinata/sdk": "^2.1.0",
+    "@pinata/sdk": "^1.1.23",
     "base64-sol": "^1.1.0",
     "dotenv": "^16.0.0",
     "fs": "^0.0.1-security",

--- a/test/unit/basicNft.test.js
+++ b/test/unit/basicNft.test.js
@@ -44,7 +44,7 @@ const { developmentChains } = require("../../helper-hardhat-config")
           it("Show the correct balance and owner of an NFT", async function () {
               const deployerAddress = deployer.address;
               const deployerBalance = await basicNft.balanceOf(deployerAddress)
-              const owner = await basicNft.ownerOf("0")
+              const owner = await basicNft.ownerOf("1")
 
               assert.equal(deployerBalance.toString(), "1")
               assert.equal(owner, deployerAddress)


### PR DESCRIPTION
Change `const owner = await basicNft.ownerOf("0")` to `const owner = await basicNft.ownerOf("1")`

To solve the below error

Error Image:
![pat1](https://user-images.githubusercontent.com/60979345/209567540-5e1c46a6-8461-4e57-b269-b4bb593bbb9f.png)


Error Message: 
```
Error: call revert exception; VM Exception while processing transaction: reverted with reason string "ERC721: invalid token ID" [ See: https://links.ethers.org/v5-errors-CALL_EXCEPTION ] (method="ownerOf(uint256)", data="0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000184552433732313a20696e76616c696420746f6b656e2049440000000000000000", errorArgs=["ERC721: invalid token ID"], 
errorName="Error", errorSignature="Error(string)", reason="ERC721: invalid token ID", code=CALL_EXCEPTION, version=abi/5.7.0)
```

Corrected code Image:
![pat2](https://user-images.githubusercontent.com/60979345/209567748-80bba29e-6aee-475c-b9a3-4ef14529bace.png)



