### PR TITLE
Update 04-mint.js fix console error "ERC721 invalid token ID"

### DIFF
--- a/contracts/DynamicSvgNft.sol
+++ b/contracts/DynamicSvgNft.sol
@@ -75,9 +75,8 @@ contract DynamicSvgNft is ERC721, Ownable {
             revert ERC721Metadata__URI_QueryFor_NonExistentToken();
         }
         (, int256 price, , , ) = i_priceFeed.latestRoundData();
-        int256 ethPrice = price * 1e10;
         string memory imageURI = s_lowImageURI;
-        if (ethPrice >= s_tokenIdToHighValues[tokenId]) {
+        if (price >= s_tokenIdToHighValues[tokenId]) {
             imageURI = s_highImageURI;
         }
         return

--- a/contracts/DynamicSvgNft.sol
+++ b/contracts/DynamicSvgNft.sol
@@ -75,8 +75,9 @@ contract DynamicSvgNft is ERC721, Ownable {
             revert ERC721Metadata__URI_QueryFor_NonExistentToken();
         }
         (, int256 price, , , ) = i_priceFeed.latestRoundData();
+        int256 ethPrice = price * 1e10;
         string memory imageURI = s_lowImageURI;
-        if (price >= s_tokenIdToHighValues[tokenId]) {
+        if (ethPrice >= s_tokenIdToHighValues[tokenId]) {
             imageURI = s_highImageURI;
         }
         return

--- a/deploy/04-mint.js
+++ b/deploy/04-mint.js
@@ -27,6 +27,7 @@ module.exports = async ({ getNamedAccounts }) => {
         setTimeout(() => reject("Timeout: 'NFTMinted' event did not fire"), 300000) // 5 minute timeout time
         // setup listener for our event
         randomIpfsNft.once("NftMinted", async () => {
+            console.log(`Random IPFS NFT index 0 tokenURI: ${await randomIpfsNft.tokenURI(0)}`)
             resolve()
         })
         if (chainId == 31337) {
@@ -35,6 +36,5 @@ module.exports = async ({ getNamedAccounts }) => {
             await vrfCoordinatorV2Mock.fulfillRandomWords(requestId, randomIpfsNft.address)
         }
     })
-    console.log(`Random IPFS NFT index 0 tokenURI: ${await randomIpfsNft.tokenURI(0)}`)
 }
 module.exports.tags = ["all", "mint"]


### PR DESCRIPTION
Greetings!

After we deployed the three contracts to the testnet and set the VRF consumer settings, an error will occur when executing "yarn hardhat deploy --network goerli --tags mint".

I think this is because there is no any NFT on the new contract. When we call the requestNft function, we will start to request the VRF to get the random number. After the random number is obtained, the NFT will be produced, but before that, we called tokenURI(0) first, so an error will occur.

So I think console.log should be placed inside contract.once.

![yarn hardhat deploy](https://user-images.githubusercontent.com/104891984/215971024-249962c7-ce36-42d0-a329-b854873bbdca.png)

![ERC721-invalid-tokenId](https://user-images.githubusercontent.com/104891984/215970458-7842ca45-2918-4f98-9da8-083e65215896.png)
