### PR TITLE
event emit value corrected

### DIFF
--- a/contracts/DynamicSvgNft.sol
+++ b/contracts/DynamicSvgNft.sol
@@ -53,7 +53,7 @@ contract DynamicSvgNft is ERC721, Ownable {
         s_tokenIdToHighValues[s_tokenCounter] = highValue;
         _safeMint(msg.sender, s_tokenCounter);
         s_tokenCounter = s_tokenCounter + 1;
-        emit CreatedNFT(s_tokenCounter, highValue);
+        emit CreatedNFT(s_tokenCounter - 1, highValue);
     }
 
     // You could also just upload the raw SVG and have solildity convert it!


### PR DESCRIPTION
For the `CreatedNFT` event to `emit` the correct value,  it needed to be decremented by 1 inside the `emit` or the `s_tokenCounter` needed to be incremented after the `emit`. 

This PR fixes it by using the first method.