### PR TITLE
CreatedNft should be emitted before tokenCounter increment

### DIFF
--- a/contracts/DynamicSvgNft.sol
+++ b/contracts/DynamicSvgNft.sol
@@ -52,8 +52,9 @@ contract DynamicSvgNft is ERC721, Ownable {
     function mintNft(int256 highValue) public {
         s_tokenIdToHighValues[s_tokenCounter] = highValue;
         _safeMint(msg.sender, s_tokenCounter);
-        s_tokenCounter = s_tokenCounter + 1;
+
         emit CreatedNFT(s_tokenCounter, highValue);
+        s_tokenCounter = s_tokenCounter + 1;
     }
 
     // You could also just upload the raw SVG and have solildity convert it!


### PR DESCRIPTION
-emit CreatedNft will produce tokenId+1  for  highValue provided
-getTokenCounter() will Produce lastTokenId+1 value which will be reverted with error()
